### PR TITLE
Big change in the Augmentation structure. 

### DIFF
--- a/examples/example_ecvl_eddl.cpp
+++ b/examples/example_ecvl_eddl.cpp
@@ -12,6 +12,9 @@
 */
 
 #include <iostream>
+#include <sstream>
+#include <unordered_map>
+
 #include "ecvl/core.h"
 #include "ecvl/support_eddl.h"
 #include "ecvl/augmentations.h"
@@ -63,6 +66,21 @@ int main()
     View<DataType::float32> view;
     cout << "Executing TensorToView" << endl;
     TensorToView(t, view);
+
+	//SequentialAugmentationContainer
+	//	AugRotate angle=[-5,5] center=(0,0) scale=0.5 interp="linear"
+	//	AugAdditiveLaplaceNoise std_dev=[0,51]
+	//	AugCoarseDropout p=[0,0.55] drop_size=[0.02,0.1] per_channel=0,
+	//	AugAdditivePoissonNoise lambda=[0,40]
+	//	AugResizeDim dims=(30,30) interp="linear"
+	//end
+
+	stringstream ss(
+		"SequentialAugmentationContainer\n"
+		"    AugRotate angle=[-5,5] center=(0,0) scale=0.5 interp=\"linear\"\n"
+		"end\n"
+	);
+	auto newdeal_augs = Augmentation::make(ss);
 
     // Create the augmentations to be applied to the dataset images during training and test.
     // nullptr is given as augmentation for validation because this split doesn't exist in the mnist dataset.

--- a/examples/example_ecvl_eddl.cpp
+++ b/examples/example_ecvl_eddl.cpp
@@ -70,7 +70,7 @@ int main()
 	//SequentialAugmentationContainer
 	//	AugRotate angle=[-5,5] center=(0,0) scale=0.5 interp="linear"
 	//	AugAdditiveLaplaceNoise std_dev=[0,51]
-	//	AugCoarseDropout p=[0,0.55] drop_size=[0.02,0.1] per_channel=0,
+	//	AugCoarseDropout p=[0,0.55] drop_size=[0.02,0.1] per_channel=0
 	//	AugAdditivePoissonNoise lambda=[0,40]
 	//	AugResizeDim dims=(30,30) interp="linear"
 	//end
@@ -78,6 +78,10 @@ int main()
 	stringstream ss(
 		"SequentialAugmentationContainer\n"
 		"    AugRotate angle=[-5,5] center=(0,0) scale=0.5 interp=\"linear\"\n"
+		"    AugAdditiveLaplaceNoise std_dev=[0,0.51]\n"
+		"    AugCoarseDropout p=[0,0.55] drop_size=[0.02,0.1] per_channel=0\n"
+		"    AugAdditivePoissonNoise lambda=[0,40]\n"
+		"    AugResizeDim dims=(30,30) interp=\"linear\"\n"
 		"end\n"
 	);
 	auto newdeal_augs = Augmentation::make(ss);
@@ -100,7 +104,7 @@ int main()
 
     int batch_size = 64;
     cout << "Creating a DLDataset" << endl;
-    DLDataset d("../examples/data/mnist/mnist.yml", batch_size, move(dataset_augmentations), ColorType::GRAY);
+    DLDataset d("../examples/data/mnist/mnist.yml", batch_size, dataset_augmentations, ColorType::GRAY);
 
     // Allocate memory for x and y tensors
     cout << "Create x and y" << endl;

--- a/examples/example_ecvl_eddl.cpp
+++ b/examples/example_ecvl_eddl.cpp
@@ -32,7 +32,7 @@ int main()
     }
 
     // Create an augmentation sequence to be applied to the image
-    auto augs = make_unique<SequentialAugmentationContainer>(
+    auto augs = make_shared<SequentialAugmentationContainer>(
         AugRotate({ -5, 5 }),
         AugMirror(.5),
         AugFlip(.5),
@@ -74,7 +74,6 @@ int main()
 	//	AugAdditivePoissonNoise lambda=[0,40]
 	//	AugResizeDim dims=(30,30) interp="linear"
 	//end
-
 	stringstream ss(
 		"SequentialAugmentationContainer\n"
 		"    AugRotate angle=[-5,5] center=(0,0) scale=0.5 interp=\"linear\"\n"
@@ -84,11 +83,11 @@ int main()
 		"    AugResizeDim dims=(30,30) interp=\"linear\"\n"
 		"end\n"
 	);
-	auto newdeal_augs = Augmentation::make(ss);
+	auto newdeal_augs = AugmentationFactory::create(ss);
 
     // Create the augmentations to be applied to the dataset images during training and test.
     // nullptr is given as augmentation for validation because this split doesn't exist in the mnist dataset.
-    auto training_augs = make_unique<SequentialAugmentationContainer>(
+    auto training_augs = make_shared<SequentialAugmentationContainer>(
         AugRotate({ -5, 5 }),
         AugAdditiveLaplaceNoise({ 0, 0.2 * 255 }),
         AugCoarseDropout({ 0, 0.55 }, { 0.02,0.1 }, 0),
@@ -96,11 +95,11 @@ int main()
         AugResizeDim({ 30, 30 })
         );
 
-    auto test_augs = make_unique<SequentialAugmentationContainer>(
+    auto test_augs = make_shared<SequentialAugmentationContainer>(
         AugResizeDim({ 30, 30 })
         );
-	
-    DatasetAugmentations dataset_augmentations{ {move(training_augs), nullptr, move(test_augs) } };
+
+    DatasetAugmentations dataset_augmentations{ {training_augs, nullptr, test_augs } };
 
     int batch_size = 64;
     cout << "Creating a DLDataset" << endl;

--- a/modules/eddl/include/ecvl/augmentations.h
+++ b/modules/eddl/include/ecvl/augmentations.h
@@ -196,10 +196,12 @@ class SequentialAugmentationContainer : public Augmentation {
             x->Apply(img, gt);
         }
     }
-	std::vector<std::shared_ptr<Augmentation>> augs_;   /**< @brief vector containing the Augmentation to be applied */
+    std::vector<std::shared_ptr<Augmentation>> augs_;   /**< @brief vector containing the Augmentation to be applied */
 public:
     template<typename ...Ts>
     SequentialAugmentationContainer(Ts&&... t) : augs_({ std::make_shared<Ts>(std::forward<Ts>(t))... }) {}
+
+    SequentialAugmentationContainer(std::vector<std::shared_ptr<Augmentation>> augs) : augs_(augs) {}
 
 	SequentialAugmentationContainer(std::istream& is) {
 		while (true) {

--- a/modules/eddl/include/ecvl/support_eddl.h
+++ b/modules/eddl/include/ecvl/support_eddl.h
@@ -44,6 +44,13 @@ public:
 		augs_[2] = unique_ptr<Augmentation>(augs[2]);
 	}
 
+	DatasetAugmentations(const DatasetAugmentations& other) 
+	{
+		augs_[0] = other.augs_[0] ? other.augs_[0]->clone() : nullptr;
+		augs_[1] = other.augs_[0] ? other.augs_[0]->clone() : nullptr;
+		augs_[2] = other.augs_[0] ? other.augs_[0]->clone() : nullptr;
+	}
+
 	// Getters: YAGNI
 
     void Apply(SplitType st, Image& img, const Image& gt = Image())

--- a/modules/eddl/include/ecvl/support_eddl.h
+++ b/modules/eddl/include/ecvl/support_eddl.h
@@ -26,30 +26,15 @@ namespace ecvl
 
 This class represent the augmentations which will be applied to each split.
 
-During construction the object becomes owner of the Augmentations whose pointers
-were passed to the constructor.
+This is just a shallow container for the Augmentations
 
 @anchor DatasetAugmentations
 */
 class DatasetAugmentations {
-    std::array<unique_ptr<Augmentation>, 3> augs_;
+    std::array<shared_ptr<Augmentation>, 3> augs_;
 public:
-	DatasetAugmentations(std::array<unique_ptr<Augmentation>, 3> augs = { nullptr,nullptr,nullptr })
-		: augs_{ std::move(augs) } {}
-
-    DatasetAugmentations(std::array<Augmentation*, 3> augs) 
-	{
-		augs_[0] = unique_ptr<Augmentation>(augs[0]);
-		augs_[1] = unique_ptr<Augmentation>(augs[1]);
-		augs_[2] = unique_ptr<Augmentation>(augs[2]);
-	}
-
-	DatasetAugmentations(const DatasetAugmentations& other) 
-	{
-		augs_[0] = other.augs_[0] ? other.augs_[0]->clone() : nullptr;
-		augs_[1] = other.augs_[0] ? other.augs_[0]->clone() : nullptr;
-		augs_[2] = other.augs_[0] ? other.augs_[0]->clone() : nullptr;
-	}
+	DatasetAugmentations(std::array<shared_ptr<Augmentation>, 3> augs = { nullptr,nullptr,nullptr })
+		: augs_(augs) {}
 
 	// Getters: YAGNI
 

--- a/modules/eddl/src/augmentations.cpp
+++ b/modules/eddl/src/augmentations.cpp
@@ -16,4 +16,25 @@
 namespace ecvl
 {
 std::default_random_engine AugmentationParam::re_(std::random_device{}());
+
+// This factory must be manually populated! Don't forget to do it, otherwise no creation from streams
+
+#define AUG(x) if (name == #x) return std::make_shared<x>(is)
+std::shared_ptr<Augmentation> AugmentationFactory::create(const std::string& name, std::istream& is) 
+{
+    AUG(SequentialAugmentationContainer);
+    AUG(AugRotate);
+    AUG(AugResizeDim);
+    AUG(AugResizeScale);
+    AUG(AugFlip);
+    AUG(AugMirror);
+    AUG(AugGaussianBlur);
+    AUG(AugAdditiveLaplaceNoise);
+    AUG(AugAdditivePoissonNoise);
+    AUG(AugGammaContrast);
+    AUG(AugCoarseDropout);
+
+    return nullptr; // Maybe throw?
+}
+
 } // namespace ecvl


### PR DESCRIPTION
We have now the ability to create augmentations from a scripting description, like:
```
SequentialAugmentationContainer
	AugRotate angle=[-5,5] center=(0,0) scale=0.5 interp="linear"
	AugAdditiveLaplaceNoise std_dev=[0,51]
	AugCoarseDropout p=[0,0.55] drop_size=[0.02,0.1] per_channel=0
	AugAdditivePoissonNoise lambda=[0,40]
	AugResizeDim dims=(30,30) interp="linear"
end
```
This required a Factory with CRTP and other magic. I also included a virtual constructor so that we are now able to copy both AugmentationContainers and DatasetAugmentations.

It's still a mess all in one .h file. Definitely needing a fixup. Ideas:
- merge `params` and `AugmentationParams`
- create a class for managing map of parsed params, with methods for requesting specific parameters also requesting the type, with simpler assignment to the proper variable
- unify interpolation param parsing, i.e. string to enum. 